### PR TITLE
Enhanced command logging for build environments

### DIFF
--- a/admin/Deny-RepoRootBranches.ps1
+++ b/admin/Deny-RepoRootBranches.ps1
@@ -30,6 +30,19 @@ param (
 
 $InformationPreference = "Continue"
 
+
+function Write-CommandLog {
+    param (
+        [Parameter(Mandatory, Position = 0)]
+        [string]
+        $Command
+    )
+    
+    $tfPrefix = if ($env:TF_BUILD) { "##[command]" } else { "" }
+
+    Write-Host -ForegroundColor 'cyan' "$tfPrefix$Command"
+}
+
 function Invoke-ShellCommand {
     param (
         [Parameter(Mandatory, Position = 0)]
@@ -37,7 +50,7 @@ function Invoke-ShellCommand {
         $Command
     )
 
-    Write-Host -ForegroundColor 'cyan' "$Command"
+    Write-CommandLog $Command
     Invoke-Expression "& $($Command)"
     if (-not $?) {
         Write-Error "Failed to invoke shell command. Exit code: $($LastExitCode)"


### PR DESCRIPTION
Introduced a new function `Write-CommandLog` to standardize the output of shell commands across different environments, specifically to support both regular execution and Azure DevOps build pipelines by prefixing logs with "##[command]" when running in the latter. This improves the visibility and diagnosability of command execution within CI/CD pipelines. Refactored the `Invoke-ShellCommand` function to use this new logging approach.